### PR TITLE
#147: Added support for intents

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -1,13 +1,15 @@
 import discord
 from discord.ext import commands
 
+intents = discord.Intents.default()
+intents.members = True
+bot = commands.Bot(command_prefix="?", intents=intents, case_insensitive=True)
+
 initial_extensions = ['utils.global_error_manager', 'testing.integration.integration_manager', 'sneaselcommands.list',
                       'sneaselcommands.support', 'sneaselcommands.leaderboards', 'sneaselcommands.ranks',
                       'sneaselcommands.configure', 'sneaselcommands.dex', 'sneaselcommands.refresh',
                       'sneaselcommands.raids.raid', 'sneaselcommands.raids.close', 'sneaselcommands.raids.update',
                       'sneaselcommands.raids.status', 'sneaselcommands.raids.raids']
-
-bot = commands.Bot(command_prefix="?", case_insensitive=True)
 for extension in initial_extensions:
     bot.load_extension(extension)
 


### PR DESCRIPTION
Discord API suddenly added new breaking feature with due date 7 oct.
Requires bots to opt-in to intents, Sneasel requires some default intents and private intent members.

This PR adds support for those intents. Will require a bump of discord.py on PROD as well.

Closes: #147