### PR TITLE
fix: Members can now submit to leaderboards that are capitalized

### DIFF
--- a/sneaselcommands/leaderboards.py
+++ b/sneaselcommands/leaderboards.py
@@ -115,7 +115,7 @@ class Leaderboards(commands.Cog):
         # extract data
         try:
             score = float(score.replace(",", "."))
-            invoked_leaderboard = ctx.invoked_with
+            invoked_leaderboard = ctx.invoked_with.lower()
             if invoked_leaderboard == "leaderboard":
                 await ctx.send("Please submit to a specific leaderboard, such as jogger, type ?help for example usage.")
                 return


### PR DESCRIPTION
Would previously crash when capitalized table didn't exist. Oops.