### PR TITLE
fix: Disabling raid command as preparation for server remodel

### DIFF
--- a/sneaselcommands/raids/raid.py
+++ b/sneaselcommands/raids/raid.py
@@ -277,15 +277,18 @@ class Raid(commands.Cog):
         Type ?status, to ask Sneasel to re-send the raid information
         Type ?close, to close the raid channel early
         """
-        args = maybe_replace_time(*args)
-        validated_report = _validate_report(args)
-        legal_args = _remove_illegal_characters(args)
-        if len(validated_report) > 1:
-            await ctx.send(f"{validated_report} {ctx.author.mention}")
-            return
+        await ctx.send(f"[?raid, ?raids] commands are temporarily disabled {ctx.author.mention}")
+        return
 
-        await _create_channel_and_information(self.bot, ctx, legal_args)
-        await update_raids_channel(self.bot, ctx)
+        # args = maybe_replace_time(*args)
+        # validated_report = _validate_report(args)
+        # legal_args = _remove_illegal_characters(args)
+        # if len(validated_report) > 1:
+        #     await ctx.send(f"{validated_report} {ctx.author.mention}")
+        #     return
+        #
+        # await _create_channel_and_information(self.bot, ctx, legal_args)
+        # await update_raids_channel(self.bot, ctx)
 
     @raid.error
     async def raid_on_error(self, _, error):

--- a/sneaselcommands/raids/raids.py
+++ b/sneaselcommands/raids/raids.py
@@ -70,22 +70,25 @@ class Raids(commands.Cog):
 
         Usage: ?raids
         """
-        active_raids_dict = execute_statement(
-            statement=f"SELECT * from {tables.ACTIVE_RAID_CHANNEL_OWNERS} ORDER BY hatch_time"
-        ).all(as_dict=True)
+        await ctx.send(f"[?raid, ?raids] commands are temporarily disabled {ctx.author.mention}")
+        return
 
-        embed = _create_embed(ctx, active_raids_dict)
-
-        raids_channel = discord.utils.get(ctx.guild.channels, name=constants.RAID_ACTIVES_CHANNEL)
-        if raids_channel is None:
-            await pm_dev_error(self.bot, "Can't find the raids channel to post list of active raids", "raids")
-            return
-
-        embed_message = await find_first_embed_in_channel(self.bot, raids_channel, "raids listing", should_pm=False)
-        if embed_message is None:
-            await raids_channel.send(embed=embed)
-        else:
-            await embed_message.edit(embed=embed)
+        # active_raids_dict = execute_statement(
+        #     statement=f"SELECT * from {tables.ACTIVE_RAID_CHANNEL_OWNERS} ORDER BY hatch_time"
+        # ).all(as_dict=True)
+        #
+        # embed = _create_embed(ctx, active_raids_dict)
+        #
+        # raids_channel = discord.utils.get(ctx.guild.channels, name=constants.RAID_ACTIVES_CHANNEL)
+        # if raids_channel is None:
+        #     await pm_dev_error(self.bot, "Can't find the raids channel to post list of active raids", "raids")
+        #     return
+        #
+        # embed_message = await find_first_embed_in_channel(self.bot, raids_channel, "raids listing", should_pm=False)
+        # if embed_message is None:
+        #     await raids_channel.send(embed=embed)
+        # else:
+        #     await embed_message.edit(embed=embed)
 
     @raids.error
     async def raids_on_error(self, _, error):

--- a/testing/integration/integration_manager.py
+++ b/testing/integration/integration_manager.py
@@ -56,7 +56,7 @@ class TestManager(commands.Cog):
             await support_integration.run_tests(ctx, self.bot)
             await configure_integration.run_tests(self.bot, ctx)
             await dex_integration.run_tests(self.bot, ctx)
-            await raid_integration.run_tests(self.bot, ctx)
+            # await raid_integration.run_tests(self.bot, ctx) # TODO: temporary disables, to be replaced with threads
             await rolewindow_integration.run_tests(self.bot, ctx)
             await trainercode_integration.run_tests(self.bot, ctx)
             await roles_integration.run_tests(self.bot, ctx)


### PR DESCRIPTION
New server remodel will not include a raids category with created raids or an always active raids-active channel. Instead we should simplify the command to just create a thread that auto closes after a while. Until then, disabling the command